### PR TITLE
Added clearer descriptions of priority ping frequency.

### DIFF
--- a/src/commands/reminder/priority.ts
+++ b/src/commands/reminder/priority.ts
@@ -10,7 +10,7 @@ module.exports = {
 		.addIntegerOption(option =>
 			option
 				.setName("priority")
-				.setDescription("Can either be HIGH, MEDIUM or LOW priority")
+				.setDescription("Can either be HIGH(7d, 24h, 12h, 2h, 1h, 30m), MEDIUM(24h, 2h) or LOW priority")
 				.setRequired(true)
 				.addChoice("LOW", 0)
 				.addChoice("MEDIUM", 1)


### PR DESCRIPTION
One frequent problem with using the priority command is that you aren't always sure what the ping frequency is.

This commit hopes to fix the issue.