### PR TITLE
🐛fixed monthIndex being off by 1

### DIFF
--- a/src/interactions/modals/due-date.ts
+++ b/src/interactions/modals/due-date.ts
@@ -22,9 +22,9 @@ export default class extends BaseModal<Entry, GuildCache> {
 		const hourStr = helper.text("hour")!
 		const minuteStr = helper.text("minute")!
 
-		const monthIndex = DateHelper.nameOfMonths
+		const monthIndex = (DateHelper.nameOfMonths
 			.map(m => m.toLowerCase())
-			.indexOf(monthStr.toLowerCase())
+			.indexOf(monthStr.toLowerCase())) + 1
 		const day = isNaN(+dayStr) ? ((error = "Day must be a number"), -1) : +dayStr
 		const month = monthIndex === -1 ? ((error = "Month is not valid"), -1) : monthIndex
 		const year = isNaN(+yearStr) ? ((error = "Year must be a number"), -1) : +yearStr


### PR DESCRIPTION
### Months with 31 days were not being recognised as 31 month days

### What was causing this?

``` ts
const monthIndex = DateHelper.nameOfMonths
			.map(m => m.toLowerCase())
			.indexOf(monthStr.toLowerCase())
```
Since lists start from index 0, this would return 6 as July's `monthIndex`

### How it was fixed

``` ts
const monthIndex = (DateHelper.nameOfMonths
			.map(m => m.toLowerCase())
			.indexOf(monthStr.toLowerCase())) + 1
```
Incremented the return from the function by one so that `monthIndex` _actually_ corresponds to the month
